### PR TITLE
Remove x-checker-data fields

### DIFF
--- a/manifests/docs.json
+++ b/manifests/docs.json
@@ -13,200 +13,102 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/27/45/377f7e32a5c93d94cd56542349b34efab5ca3f9e2fd5a68c5e93169aa32d/Babel-2.15.0-py3-none-any.whl",
-                    "sha256": "08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "Babel",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
-                    "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "MarkupSafe"
-                    }
+                    "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl",
-                    "sha256": "b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "alabaster",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
-                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "certifi",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "charset-normalizer"
-                    }
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl",
-                    "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "docutils",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "idna",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl",
-                    "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "imagesize",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl",
-                    "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "jinja2",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
-                    "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "packaging",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
-                    "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "requests",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "url": "https://files.pythonhosted.org/packages/24/e8/09e8d662a9675a4e4f5dd7a8e6127b463a091d2703ed931a64aa66d00065/requests-2.32.0-py3-none-any.whl",
+                    "sha256": "f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl",
-                    "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "snowballstemmer",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/48/17/325cf6a257d84751a48ae90752b3d8fe0be8f9535b6253add61c49d0d9bc/sphinx-7.1.2-py3-none-any.whl",
-                    "sha256": "d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinx",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/56/89/fea3fbf6785b388e6cb8a1beaf62f96e80b37311bdeed6e133388a732426/sphinxcontrib_applehelp-1.0.8-py3-none-any.whl",
-                    "sha256": "cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_applehelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a0/52/1049d918d1d1c72857d285c3f0c64c1cbe0be394ce1c93a3d2aa4f39fe3b/sphinxcontrib_devhelp-1.0.6-py3-none-any.whl",
-                    "sha256": "6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_devhelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/c2/e9/74c4cda5b409af3222fda38f0774e616011bc935f639dbc0da5ca2d1be7d/sphinxcontrib_htmlhelp-2.0.5-py3-none-any.whl",
-                    "sha256": "393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_htmlhelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
-                    "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_jsmath",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/80/b3/1beac14a88654d2e5120d0143b49be5ad450b86eb1963523d8dbdcc51eb2/sphinxcontrib_qthelp-1.0.7-py3-none-any.whl",
-                    "sha256": "e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_qthelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/38/24/228bb903ea87b9e08ab33470e6102402a644127108c7117ac9c00d849f82/sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl",
-                    "sha256": "326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_serializinghtml",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
-                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "urllib3",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
                 }
             ],
             "cleanup": [
@@ -223,220 +125,112 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/27/45/377f7e32a5c93d94cd56542349b34efab5ca3f9e2fd5a68c5e93169aa32d/Babel-2.15.0-py3-none-any.whl",
-                    "sha256": "08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "Babel",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
-                    "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "MarkupSafe"
-                    }
+                    "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl",
-                    "sha256": "b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "alabaster",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
-                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "certifi",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "charset-normalizer"
-                    }
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl",
-                    "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "docutils",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "idna",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl",
-                    "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "imagesize",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl",
-                    "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "jinja2",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
-                    "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "packaging",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
-                    "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "requests",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "url": "https://files.pythonhosted.org/packages/24/e8/09e8d662a9675a4e4f5dd7a8e6127b463a091d2703ed931a64aa66d00065/requests-2.32.0-py3-none-any.whl",
+                    "sha256": "f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl",
-                    "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "snowballstemmer",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/48/17/325cf6a257d84751a48ae90752b3d8fe0be8f9535b6253add61c49d0d9bc/sphinx-7.1.2-py3-none-any.whl",
-                    "sha256": "d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinx",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ea/46/00fda84467815c29951a9c91e3ae7503c409ddad04373e7cfc78daad4300/sphinx_rtd_theme-2.0.0-py2.py3-none-any.whl",
-                    "sha256": "ec93d0856dc280cf3aee9a4c9807c60e027c7f7b461b77aeffed682e68f0e586",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinx_rtd_theme",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "ec93d0856dc280cf3aee9a4c9807c60e027c7f7b461b77aeffed682e68f0e586"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/56/89/fea3fbf6785b388e6cb8a1beaf62f96e80b37311bdeed6e133388a732426/sphinxcontrib_applehelp-1.0.8-py3-none-any.whl",
-                    "sha256": "cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_applehelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a0/52/1049d918d1d1c72857d285c3f0c64c1cbe0be394ce1c93a3d2aa4f39fe3b/sphinxcontrib_devhelp-1.0.6-py3-none-any.whl",
-                    "sha256": "6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_devhelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/c2/e9/74c4cda5b409af3222fda38f0774e616011bc935f639dbc0da5ca2d1be7d/sphinxcontrib_htmlhelp-2.0.5-py3-none-any.whl",
-                    "sha256": "393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_htmlhelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl",
-                    "sha256": "f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_jquery",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl",
-                    "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_jsmath",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/80/b3/1beac14a88654d2e5120d0143b49be5ad450b86eb1963523d8dbdcc51eb2/sphinxcontrib_qthelp-1.0.7-py3-none-any.whl",
-                    "sha256": "e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_qthelp",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/38/24/228bb903ea87b9e08ab33470e6102402a644127108c7117ac9c00d849f82/sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl",
-                    "sha256": "326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "sphinxcontrib_serializinghtml",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
-                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "urllib3",
-                        "packagetype": "bdist_wheel"
-                    }
+                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
The docs manifest is generated for each LOOT release, so we don't want to be updating it between releases.