### PR TITLE
update deprecated boost url

### DIFF
--- a/io.github.loot.loot.yml
+++ b/io.github.loot.loot.yml
@@ -38,7 +38,7 @@ modules:
       - ./b2 link=static runtime-link=shared variant=release cxxflags="-std=c++17 -fPIC" --with-locale install
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2
+        url: https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2
         sha256: 7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617
 
   - name: libtbb


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
