### PR TITLE
Update runtime to 6.10

### DIFF
--- a/io.github.loot.loot.yml
+++ b/io.github.loot.loot.yml
@@ -1,6 +1,6 @@
 app-id: io.github.loot.loot
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: LOOT
 finish-args:
@@ -49,6 +49,18 @@ finish-args:
 
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/*.a
+  - /lib/pkgconfig
+  - /lib/python3.10
+  - /lib/x86_64-linux-gnu
+  - /share/doc/libogdf
+  - /share/doc/TBB
+  - /share/tomlplusplus
+
 modules:
   - name: Boost
     buildsystem: simple
@@ -101,19 +113,6 @@ modules:
       - type: archive
         url: https://github.com/marzer/tomlplusplus/archive/v3.4.0.tar.gz
         sha256: 8517f65938a4faae9ccf8ebb36631a38c1cadfb5efa85d9a72e15b9e97d25155
-
-  - name: fmt
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DFMT_DOC=OFF
-      - -DFMT_TEST=OFF
-      - -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    sources:
-      - type: archive
-        url: https://github.com/fmtlib/fmt/archive/refs/tags/12.0.0.tar.gz
-        sha256: aa3e8fbb6a0066c03454434add1f1fc23299e85758ceec0d7d2d974431481e40
 
   - name: spdlog
     buildsystem: cmake-ninja
@@ -187,13 +186,4 @@ modules:
       - type: file
         url: https://github.com/TinyTinni/ValveFileVDF/archive/refs/tags/v1.1.0.tar.gz
         sha256: 9149a6b01ca857f49f5660d608639acd579542bf862ad23e9cbf4c1e80ade55e
-cleanup:
-  - /include
-  - /lib/cmake
-  - /lib/*.a
-  - /lib/pkgconfig
-  - /lib/python3.10
-  - /lib/x86_64-linux-gnu
-  - /share/doc/libogdf
-  - /share/doc/TBB
-  - /share/tomlplusplus
+


### PR DESCRIPTION
Update runtime to 6.10.

Also, drop the fmtlib module, which is already provided by the runtime.

Fixes: https://github.com/flathub/io.github.loot.loot/issues/23