### PR TITLE
Improve cleanup commands

### DIFF
--- a/io.github.loot.loot.yml
+++ b/io.github.loot.loot.yml
@@ -49,6 +49,17 @@ finish-args:
 
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/ogdf
+  - /share/tomlplusplus
+  - "*.la"
+  - "*.a"
+
 modules:
   - name: OGDF
     buildsystem: cmake-ninja
@@ -148,6 +159,8 @@ modules:
 
   - name: svg_to_ico
     buildsystem: simple
+    cleanup:
+      - "/bin"
     build-commands:
       - tar -xf svg_to_ico.tar.xz
       - install -D svg_to_ico /app/bin/svg_to_ico
@@ -185,14 +198,3 @@ modules:
         url: https://github.com/TinyTinni/ValveFileVDF/archive/refs/tags/v1.1.0.tar.gz
         sha256: 9149a6b01ca857f49f5660d608639acd579542bf862ad23e9cbf4c1e80ade55e
         dest: ValveFileVDF
-cleanup:
-  - /bin/svg_to_ico
-  - /include
-  - /lib/cmake
-  - /lib/*.a
-  - /lib/pkgconfig
-  - /lib/python3.10
-  - /lib/x86_64-linux-gnu
-  - /share/doc/libogdf
-  - /share/doc/TBB
-  - /share/tomlplusplus

--- a/io.github.loot.loot.yml
+++ b/io.github.loot.loot.yml
@@ -57,7 +57,6 @@ cleanup:
   - /share/doc
   - /share/ogdf
   - /share/tomlplusplus
-  - "*.la"
   - "*.a"
 
 modules:


### PR DESCRIPTION
Improve cleanup commands to reduce the Flatpak size.

The installed size has been reduced from **28.3 MB** to **16.3 MB**.

See also: https://github.com/loot/loot/issues/2197